### PR TITLE
Replace ActivityManager.runningAppProcesses method

### DIFF
--- a/library/src/main/java/com/dpforge/primaree/Primaree.kt
+++ b/library/src/main/java/com/dpforge/primaree/Primaree.kt
@@ -1,9 +1,11 @@
 package com.dpforge.primaree
 
-import android.app.ActivityManager
 import android.app.Application
-import android.content.Context
+import android.os.Build
 import android.os.Process
+import android.os.StrictMode
+import java.io.BufferedReader
+import java.io.FileReader
 
 fun Application.runIfPrimaryProcess(block: () -> Unit) {
     if (isPrimaryProcess) {
@@ -16,7 +18,33 @@ val Application.isPrimaryProcess: Boolean
 
 val Application.currentProcessFullName: String?
     get() {
-        val myPid = Process.myPid()
-        val am = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager?
-        return am?.runningAppProcesses?.find { myPid == it.pid }?.processName
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            Application.getProcessName()
+        } else {
+            val myPid = Process.myPid()
+            getProcessName(myPid)
+        }
     }
+
+private fun getProcessName(pid: Int): String? {
+    if (pid <= 0) {
+        return null
+    }
+
+    return runCatching {
+        val bufferedReader: BufferedReader
+        val oldThreadPolicy = StrictMode.allowThreadDiskReads()
+
+        try {
+            bufferedReader = BufferedReader(FileReader("/proc/$pid/cmdline"))
+        } finally {
+            StrictMode.setThreadPolicy(oldThreadPolicy)
+        }
+
+        val processName = bufferedReader.readLine().trim { it <= ' ' }
+
+        runCatching { bufferedReader.close() }
+
+        return@runCatching processName
+    }.getOrNull()
+}


### PR DESCRIPTION
ActivityManager.runningAppProcesses is intended for debugging and sometimes returns null.
Application.getProcessName() is is the preferred method for 28+ API versions. 
For lower versions "/proc/PID/cmdline"  is used.